### PR TITLE
Fix: get number of line before fetching temp file

### DIFF
--- a/brn.c
+++ b/brn.c
@@ -112,8 +112,14 @@ flist_from_lines(char *filename)
 
 	struct flist r;
 
-	size_t actual_length = 100;
-	r.files = malloc(sizeof(struct fname) * actual_length);
+	size_t n_lines = 0;
+	char temp_line[NAME_MAX];
+	while (fgets(temp_line, sizeof(temp_line), fptr)) {
+		n_lines++;
+	}
+	fseek(fptr, 0, SEEK_SET);
+
+	r.files = malloc(sizeof(struct fname) * n_lines);
 
 	size_t counter = 0;
 	while (true) {


### PR DESCRIPTION
This removes the 100 element limit and makes the program more dynamic.

I would suggest to use space indent instead of tabs, following standards. It's been quite annoying to edit the source file.